### PR TITLE
Improve jenkins-data.sh error reporting

### DIFF
--- a/jenkins-data.sh
+++ b/jenkins-data.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -o pipefail
+set -eo pipefail
 
 echo "Setting up a virtualenv and installing dependencies"
 


### PR DESCRIPTION
The pipefail option is insufficient in this context
for returning a non-zero exit code. Use -e to ensure
the script exits if loading the spreadsheet or
POSTing the data fails.