### PR TITLE
Correct quarter end date

### DIFF
--- a/collector/process.py
+++ b/collector/process.py
@@ -144,7 +144,7 @@ def setup_data_types():
             },
             'Oct - Dec 2014': {
                 '_start_at': datetime.datetime(2014, 10, 01, 0, 0),
-                '_end_at': datetime.datetime(2014, 01, 01, 0, 0),
+                '_end_at': datetime.datetime(2015, 01, 01, 0, 0),
             },
             'Jan - Mar 2015': {
                 '_start_at': datetime.datetime(2015, 01, 01, 0, 0),


### PR DESCRIPTION
Fix an incorrect quarter  end date which is causing a date range to be incorrect on Transaction Explorer dashboards e.g. https://www.gov.uk/performance/co-signing-an-e-petition/transactions-per-quarter ('1 October 2014 to 31 December 2013')