### PR TITLE
159387369 import transaction exporer metrics into production

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -20,7 +20,7 @@ fi
 if [ ! -r "tools/data/services.csv" ]
 then
     echo "'tools/data/services.csv' file not present / not readable."
-    echo "Have you downloaded The Spreadsheet(TM)?"
+    echo "Have you downloaded The Spreadsheet™?"
     exit 3
 fi
 


### PR DESCRIPTION
This PR is because there is a problem somewhere in the heath robinson proxy pass stack between gov.uk performance platform / fastly and the actual API which prevents large files from being uploaded.

Quick solution is to chunk the import.

This PR also amends the facetious readme to be more typographically correct

(TLDR read the commit)